### PR TITLE
#38774 use tuple instead of leaf for po_get_domain

### DIFF
--- a/stock_block_auto_purchase_order/models/stock_rule.py
+++ b/stock_block_auto_purchase_order/models/stock_rule.py
@@ -10,4 +10,4 @@ class StockRule(models.Model):
 
     def _make_po_get_domain(self, values, partner):
         domain = super()._make_po_get_domain(values, partner)
-        return [*domain, ("block_auto_purchase_order", "=", False)]
+        return domain + (("block_auto_purchase_order", "=", False),)


### PR DESCRIPTION
Otherwise, an exception is raised when running the procurement scheduler.
The system hashes the domain for caching.